### PR TITLE
Replace template content with Zeller Construction details

### DIFF
--- a/HTML Files/about.html
+++ b/HTML Files/about.html
@@ -120,7 +120,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -173,8 +173,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -703,7 +703,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -729,11 +729,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/blog-detail.html
+++ b/HTML Files/blog-detail.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -592,7 +592,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -618,11 +618,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/cart.html
+++ b/HTML Files/cart.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -491,7 +491,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -517,11 +517,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/checkout.html
+++ b/HTML Files/checkout.html
@@ -171,7 +171,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -275,8 +275,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -488,7 +488,7 @@
                   <img src="assets/images/blog-author-img-2.jpg" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -514,11 +514,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/contact.html
+++ b/HTML Files/contact.html
@@ -119,7 +119,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -172,8 +172,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -249,8 +249,8 @@
               <figure>
                 <img class="author" src="https://placehold.co/110x110" alt="Bio Image">
               </figure>
-              <h3>Walimes Jonnie</h3>
-              <p>Director of Constro Company</p>
+              <h3>Mario Garcia</h3>
+              <p>Owner of Zeller Construction & Remodeling, LLC.</p>
               <figure>
                 <img src="assets/images/signature.png" alt="Signature Image">
               </figure>
@@ -262,23 +262,23 @@
                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="79" height="94" viewBox="0 0 79 94"> <defs> <clipPath id="clip-location_Bd"> <rect width="79" height="94"/> </clipPath> </defs> <g id="location_Bd" data-name="location B" clip-path="url(#clip-location_B)"> <path id="Path_1gfhjfjytkd" data-name="Path 1" d="M962.855,575.375a3,3,0,0,1-2.1-.861l-26.263-25.826c-11.03-11.993-13.791-27.653-7.492-42a38.334,38.334,0,0,1,34.959-23.117l1.346.009c15.262,0,27.868,8.452,33.722,22.609,6.152,14.878,3.046,31.554-7.912,42.485-.528.555-24.064,25.75-24.064,25.75a3,3,0,0,1-2.129.951Zm-.9-85.8A31.924,31.924,0,0,0,932.49,509.1c-5.313,12.1-2.954,25.342,6.31,35.419l23.963,23.559c15.027-16.085,20.179-21.585,22.274-23.488l-.164-.165c9.233-9.209,11.825-23.318,6.605-35.944a29.677,29.677,0,0,0-28.177-18.9Z" transform="translate(-922.725 -482.15)"/> <path id="Path_24cr2r" data-name="Path 2d" d="M15,6a9,9,0,1,0,9,9,9.01,9.01,0,0,0-9-9m0-6A15,15,0,1,1,0,15,15,15,0,0,1,15,0Z" transform="translate(25 26)"/> </g> </svg>
                 <div>
                   <h3>Address:</h3>
-                  <p>65 Allerton Street 901 N Pitt Str, USA</p>
+                  <p>750 Pinecrest Drive, East Peoria, IL 61611</p>
                 </div>
               </li>
               <li>
                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="fsddffsdfsdfsdf"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsfddfsdile" clip-path="url(#fsddffsdfsdfsdf)"> <path id="Pafdth_1dfhgfhgjjdfhgddffgdfgdfgdfgdfgd" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Padfth_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g></svg>
                 <div>
                   <h3>Telephone:</h3>
-                  <p>Tel:   (+380) 50 318 47 07</p>
-                  <p>Fax:  (+182) 50 318 47 07</p>
+                  <p>Tel:   (309) 738-3279</p>
+                  <p>Fax:  (309) 644-0562</p>
                 </div>
               </li>
               <li>
                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Emaidl_Bhf"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Emaidfgsdl_B" data-name="Email B" clip-path="url(#clip-Email_Bsdfhf)"> <path id="Pathsdf_1" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_2dfsdsffgs" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
                 <div>
                   <h3>Email:</h3>
-                  <p>username@domain.com</p>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
+                  <p>zeller@zeller1.com</p>
                 </div>
               </li>
             </ul>
@@ -412,7 +412,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -438,11 +438,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/core-values.html
+++ b/HTML Files/core-values.html
@@ -171,7 +171,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -275,8 +275,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -344,8 +344,8 @@
               <figure>
                 <img src="assets/images/signature.png" alt="Signature">
               </figure>
-              <h3>Walimes Jonnie</h3>
-              <h4>Director of Constro Company</h4>
+              <h3>Mario Garcia</h3>
+              <h4>Owner of Zeller Construction & Remodeling, LLC.</h4>
             </div>
           </div>
         </div>
@@ -552,7 +552,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -578,11 +578,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/history.html
+++ b/HTML Files/history.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -444,7 +444,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -470,11 +470,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/index-2.html
+++ b/HTML Files/index-2.html
@@ -174,7 +174,7 @@
                       <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                         <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
                       </a>
-                      <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+                      <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                         <i>
                           <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                           <defs>
@@ -282,8 +282,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -1033,7 +1033,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -1059,11 +1059,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/index-3.html
+++ b/HTML Files/index-3.html
@@ -334,8 +334,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -644,7 +644,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -682,7 +682,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -1093,7 +1093,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -1119,11 +1119,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/index.html
+++ b/HTML Files/index.html
@@ -125,7 +125,7 @@
                       <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                         <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
                       </a>
-                      <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+                      <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                         <i>
                           <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                           <defs>
@@ -183,8 +183,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -203,25 +203,9 @@
         <div class="f-slider-layer">
           <img src="https://douglashammond309-nghkj.wordpress.com/wp-content/uploads/2025/08/webbanner.jpg">
           <div class="f-slider-one-data">
-            <h1>Create the Building You Want Here</h1>
-            <p>Busico is a construction and architecture environmentally most responsible for any kinds of themes.</p>
-            <a href="javascript:void(0)" data-bs-toggle="modal" data-bs-target="#exampleModal" class="theme-btn">Start Consulting <i class="fa-solid fa-angles-right"></i></a>
-          </div>
-        </div>
-        <div class="f-slider-layer">
-          <img src="https://placehold.co/1900x530" alt="Project Img">
-          <div class="f-slider-one-data">
-            <h1>A Better Way To Build Your Dreams</h1>
-            <p>Busico is a construction and architecture environmentally most responsible for any kinds of themes.</p>
-            <a href="javascript:void(0)" data-bs-toggle="modal" data-bs-target="#exampleModal1" class="theme-btn">Estimate Price <i class="fa-solid fa-angles-right"></i></a>
-          </div>
-        </div>
-        <div class="f-slider-layer">
-          <img src="https://placehold.co/1900x530" alt="Project Img 2">
-          <div class="f-slider-one-data">
-            <h1>Build Innovative & Industrial Solutions</h1>
-            <p>Busico is a construction and architecture environmentally most responsible for any kinds of themes.</p>
-            <a href="javascript:void(0)" data-bs-toggle="modal" data-bs-target="#exampleModal" class="theme-btn">Start Consulting <i class="fa-solid fa-angles-right"></i></a>
+            <h1>30+ Years of Expert Construction &amp; Remodeling</h1>
+            <p>Providing Reliable Services for Residential, Commercial, and Industrial Projects</p>
+            <a href="#services" class="theme-btn">See What We Offer <i class="fa-solid fa-angles-right"></i></a>
           </div>
         </div>
       </div>
@@ -230,8 +214,11 @@
   <!-- Featured Slider One End -->
 
   <!-- Service Style One Start -->
-  <section class="gap service-style-one">
+  <section id="services" class="gap service-style-one">
     <div class="container">
+      <div class="heading text-center">
+        <h2>Services Tailored to Your Needs</h2>
+      </div>
       <div class="row">
         <div class="col-lg-4 col-md-6 col-sm-12 text-center" >
           <div class="service-data">
@@ -239,8 +226,8 @@
               <img class="light-icon" src="assets/images/icon-1.svg" alt="Icon">
               <img class="dark-icon" src="assets/images/1-icon.png" alt="Icon">
             </div>
-            <h3><a href="javascript:void(0)">Core Planning</a></h3>
-            <p>Lorem ipsum dolor sit amet, consectne auctor aliquet. Aenean sollicitudi, lorem bibendum auctor.</p>
+            <h3><a href="javascript:void(0)">Roofing</a></h3>
+            <p>Reliable installations, repairs, and replacements to protect your property.</p>
             <a class="icon" href="javascript:void(0)">
               <i class="fa-solid fa-angles-right"></i>
             </a>
@@ -252,8 +239,8 @@
               <img class="light-icon" src="assets/images/icon-2.svg" alt="Icon">
               <img class="dark-icon" src="assets/images/2-icon.png" alt="Icon">
             </div>
-            <h3><a href="javascript:void(0)">Traditional Designs</a></h3>
-            <p>Lorem ipsum dolor sit amet, consectne auctor aliquet. Aenean sollicitudi, lorem bibendum auctor.</p>
+            <h3><a href="javascript:void(0)">Siding</a></h3>
+            <p>Enhance your home’s curb appeal with durable siding solutions.</p>
             <a class="icon" href="javascript:void(0)">
               <i class="fa-solid fa-angles-right"></i>
             </a>
@@ -265,8 +252,47 @@
               <img class="light-icon" src="assets/images/icon-3.svg" alt="Icon">
               <img class="dark-icon" src="assets/images/3-icon.png" alt="Icon">
             </div>
-            <h3><a href="javascript:void(0)">Quality Materials</a></h3>
-            <p>Lorem ipsum dolor sit amet, consectne auctor aliquet. Aenean sollicitudi, lorem bibendum auctor.</p>
+            <h3><a href="javascript:void(0)">Gutters</a></h3>
+            <p>Properly installed gutters to prevent water damage.</p>
+            <a class="icon" href="javascript:void(0)">
+              <i class="fa-solid fa-angles-right"></i>
+            </a>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 col-sm-12 text-center" >
+          <div class="service-data">
+            <div class="svg-icon d-flex-all">
+              <img class="light-icon" src="assets/images/icon-1.svg" alt="Icon">
+              <img class="dark-icon" src="assets/images/1-icon.png" alt="Icon">
+            </div>
+            <h3><a href="javascript:void(0)">Painting</a></h3>
+            <p>Interior and exterior painting for a fresh, updated look.</p>
+            <a class="icon" href="javascript:void(0)">
+              <i class="fa-solid fa-angles-right"></i>
+            </a>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 col-sm-12 text-center" >
+          <div class="service-data">
+            <div class="svg-icon d-flex-all">
+              <img class="light-icon" src="assets/images/icon-2.svg" alt="Icon">
+              <img class="dark-icon" src="assets/images/2-icon.png" alt="Icon">
+            </div>
+            <h3><a href="javascript:void(0)">Kitchen Remodels</a></h3>
+            <p>Transform your kitchen with custom cabinetry, countertops, and modern designs.</p>
+            <a class="icon" href="javascript:void(0)">
+              <i class="fa-solid fa-angles-right"></i>
+            </a>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 col-sm-12 text-center" >
+          <div class="service-data">
+            <div class="svg-icon d-flex-all">
+              <img class="light-icon" src="assets/images/icon-3.svg" alt="Icon">
+              <img class="dark-icon" src="assets/images/3-icon.png" alt="Icon">
+            </div>
+            <h3><a href="javascript:void(0)">Bathroom Remodels</a></h3>
+            <p>Create a luxurious and functional bathroom with high-end finishes.</p>
             <a class="icon" href="javascript:void(0)">
               <i class="fa-solid fa-angles-right"></i>
             </a>
@@ -284,26 +310,23 @@
         <div class="col-lg-6" >
           <div class="about-data-left">
             <figure>
-              <img src="https://placehold.co/370x500" alt="About One">
+              <img src="https://placehold.co/370x500" alt="Completed project of a house">
             </figure>
             <figure class="about-image">
-              <img src="https://placehold.co/265x325" alt="About Two">
+              <img src="https://placehold.co/265x325" alt="A man fixing the roof">
             </figure>
           </div>
         </div>
         <div class="col-lg-6" >
           <div class="about-data-right">
-            <span>Welcome to Our Company</span>
-            <h2>Constro Provides a full range of services</h2>
+            <h2>Our Comprehensive Roofing and Remodeling Solutions</h2>
             <div class="about-info">
-              <p>
-                We successfully cope with tasks of varying complexity, provide long-term guarantees and regularly master new technologies. Our portfolio includes dozens of successfully completed projects of houses of different storeys, with high–quality finishes and good repairs. Building houses is our vocation!
-              </p>
-              <figure>
-                <img src="assets/images/signature.png" alt="Signature">
-              </figure>
-              <h3>Walimes Jonnie</h3>
-              <h4>Director of Constro Company</h4>
+              <p>With over 30 years of experience, Zeller Construction &amp; Remodeling, LLC. delivers high-quality craftsmanship and exceptional service to Tazewell, Peoria, and surrounding counties.</p>
+              <ul>
+                <li>From roofing to bathroom remodels.</li>
+                <li>Skilled professionals for every project.</li>
+                <li>Top-grade materials for lasting results.</li>
+              </ul>
             </div>
           </div>
         </div>
@@ -311,6 +334,30 @@
     </div>
   </section>
   <!-- About Style One End -->
+
+  <!-- About Zeller Start -->
+  <section class="gap about-style-one">
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-6" >
+          <div class="about-data-left">
+            <figure>
+              <img src="https://placehold.co/370x500" alt="Open space inside a house.">
+            </figure>
+          </div>
+        </div>
+        <div class="col-lg-6" >
+          <div class="about-data-right">
+            <h2>Transforming Homes &amp; Businesses for 30+ Years</h2>
+            <div class="about-info">
+              <p>At Zeller Construction &amp; Remodeling, LLC., we take pride in being a family-owned and locally operated business serving Tazewell, Peoria, and surrounding counties. With over 30 years of experience, we’ve built a reputation for exceptional quality, reliability, and craftsmanship in every project we undertake.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- About Zeller End -->
 
   <!-- Counter Style One Start -->
   <section class="gap no-top counter-style-one">
@@ -978,7 +1025,7 @@
                   <img src="https://placehold.co/60x60" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -1004,11 +1051,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/leadership.html
+++ b/HTML Files/leadership.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -355,7 +355,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -393,7 +393,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -431,7 +431,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -469,7 +469,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -738,7 +738,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -764,11 +764,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/login.html
+++ b/HTML Files/login.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -402,7 +402,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -428,11 +428,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/our-blog-1.html
+++ b/HTML Files/our-blog-1.html
@@ -119,7 +119,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -172,8 +172,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -430,7 +430,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -456,11 +456,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/our-blog-2.html
+++ b/HTML Files/our-blog-2.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -595,7 +595,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -621,11 +621,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/our-products.html
+++ b/HTML Files/our-products.html
@@ -175,7 +175,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -279,8 +279,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -566,7 +566,7 @@
                   <img src="assets/images/blog-author-img-2.jpg" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -592,11 +592,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/our-projects-1.html
+++ b/HTML Files/our-projects-1.html
@@ -119,7 +119,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -172,8 +172,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -432,7 +432,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -458,11 +458,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/our-projects-2.html
+++ b/HTML Files/our-projects-2.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -476,7 +476,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -502,11 +502,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/our-team.html
+++ b/HTML Files/our-team.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -340,7 +340,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -378,7 +378,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -416,7 +416,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -454,7 +454,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -492,7 +492,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -530,7 +530,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -568,7 +568,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -606,7 +606,7 @@
                   </g>
                 </svg>
               </span>
-              <p>(+380) 50 318 47 07</p>
+              <p>(309) 738-3279</p>
             </div>
             <div class="team-social-medias">
               <a href="team-detail.html">
@@ -668,7 +668,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -694,11 +694,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/product-detail.html
+++ b/HTML Files/product-detail.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -595,7 +595,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -621,11 +621,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/product-grid.html
+++ b/HTML Files/product-grid.html
@@ -175,7 +175,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -279,8 +279,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -593,7 +593,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -619,11 +619,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/product-list.html
+++ b/HTML Files/product-list.html
@@ -175,7 +175,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -279,8 +279,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -566,7 +566,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -592,11 +592,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/project-detail.html
+++ b/HTML Files/project-detail.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -521,7 +521,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -547,11 +547,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_sdf331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2ef" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1vsdf444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Pathdf_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/service-detail.html
+++ b/HTML Files/service-detail.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -516,7 +516,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -542,11 +542,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/services.html
+++ b/HTML Files/services.html
@@ -120,7 +120,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -173,8 +173,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -523,7 +523,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -549,11 +549,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Patsdfh_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24df" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>

--- a/HTML Files/team-detail.html
+++ b/HTML Files/team-detail.html
@@ -170,7 +170,7 @@
               <a href="javascript:void(0)" id="desktop-menu" class="menu-start">
                 <svg id="ham-menue" viewBox="0 0 100 100"> <path class="line line1" d="M 20,29.000046 H 80.000231 C 80.000231,29.000046 94.498839,28.817352 94.532987,66.711331 94.543142,77.980673 90.966081,81.670246 85.259173,81.668997 79.552261,81.667751 75.000211,74.999942 75.000211,74.999942 L 25.000021,25.000058" /> <path class="line line2" d="M 20,50 H 80" /> <path class="line line3" d="M 20,70.999954 H 80.000231 C 80.000231,70.999954 94.498839,71.182648 94.532987,33.288669 94.543142,22.019327 90.966081,18.329754 85.259173,18.331003 79.552261,18.332249 75.000211,25.000058 75.000211,25.000058 L 25.000021,74.999942" /> </svg>
               </a>
-              <a href="tel:+02101283492" class="theme-btn">+021 01283492 
+              <a href="tel:+13096440562" class="theme-btn">(309) 644-0562 
                 <i>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62">
                   <defs>
@@ -274,8 +274,8 @@
             <img src="assets/images/desktop-menu-img.jpg" alt="Desktop Menu Image">
           </figure>
           <h3>Get in touch</h3>
-          <p class="num">(+380) 50 318 47 07</p>
-          <p class="adrs">65 Allerton Street 901 N Pitt Str, Suite 170, VA 22314, USA</p>
+          <p class="num">(309) 738-3279</p>
+          <p class="adrs">750 Pinecrest Drive, East Peoria, IL 61611</p>
           <div class="social-medias">
               <a href="javascript:void(0)">Facebook</a>
               <a href="javascript:void(0)">Twitter</a>
@@ -351,8 +351,8 @@
                     <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="fsddffsdfsdfsdf"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsfddfsdile" clip-path="url(#fsddffsdfsdfsdf)"> <path id="Pafdth_1dfhgfhgjjdfhgddffgdfgdfgdfgdfgd" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Padfth_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g></svg>
                     <div class="t-sec">
                       <p>Telephone:</p>
-                      <span><b>Tel:</b>  (+380) 50 318 47 07</span>
-                      <span><b>Fax:</b>  (+182) 50 318 47 07</span>
+                      <span><b>Tel:</b>  (309) 738-3279</span>
+                      <span><b>Fax:</b>  (309) 644-0562</span>
                     </div>
                   </div>
                   <a href="javascript:void(0)" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
@@ -447,7 +447,7 @@
                   <img src="https://placehold.co/55x55" alt="Contact Images">
                 </figure>
               </div>
-              <p>Sales representative <span>+1 (251) 344 0 66</span> free call !</p>
+              <p>Sales representative <span>(309) 644-0562</span> free call !</p>
             </div>
             <a href="contact.html" class="theme-btn">Get a Consultation <i class="fa-solid fa-angles-right"></i></a>
           </div>
@@ -473,11 +473,11 @@
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="40" height="62" viewBox="0 0 40 62"> <defs> <clipPath id="dasdasdasd"> <rect width="40" height="62"/> </clipPath> </defs> <g id="Mobsdfsdfsdfsdfile" clip-path="url(#dasdasdasd)"> <path id="Path_331" data-name="Path 1" d="M10,6a4,4,0,0,0-4,4V50a4,4,0,0,0,4,4H28a4,4,0,0,0,4-4V10a4,4,0,0,0-4-4H10m0-6H28A10,10,0,0,1,38,10V50A10,10,0,0,1,28,60H10A10,10,0,0,1,0,50V10A10,10,0,0,1,10,0Z" transform="translate(1 1)"/> <path id="Path_2" data-name="Path 2" d="M2.5,0h7a2.5,2.5,0,0,1,0,5h-7a2.5,2.5,0,0,1,0-5Z" transform="translate(14 48)"/> </g> </svg>
-                  <p>(+380) 50 318 47 07</p>
+                  <p>(309) 738-3279</p>
                 </li>
                 <li>
                   <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="93" viewBox="0 0 102 93"> <defs> <clipPath id="clip-Email_B"> <rect width="102" height="93"/> </clipPath> </defs> <g id="Email_B" data-name="Email B" clip-path="url(#clip-Email_B)"> <path id="Path_1444" data-name="Path 1" d="M969.85,550.4,927.766,528.2l2.8-5.307,39.229,20.7,37.712-20.677,2.885,5.261Z" transform="translate(-918 -492)"/> <path id="Path_24" data-name="Path 2" d="M969.562,494.385l48.391,25.361,0,1.818c-.023,17.272-.043,42.814-.012,47.124l.012.024v.709c0,5.426-1.516,9.425-4.508,11.885a10.4,10.4,0,0,1-6.575,2.344l-75.5-.016c-3.557.071-5.965-.931-7.717-2.752-2.4-2.5-3.517-6.391-3.317-11.577l.065-1.194c.116-5.315.029-29.954-.067-46.535l-.011-1.842Zm42.386,28.988-42.411-22.227-43.2,22.238c.189,32.939.239,42.8-.143,46.148l.13.005c-.168,4.351.8,6.309,1.645,7.185a3.342,3.342,0,0,0,2.458.984l76.043-.071a4.65,4.65,0,0,0,3.16-.963c1.517-1.248,2.319-3.754,2.319-7.25h.09C1011.893,566.689,1011.9,557.566,1011.947,523.373Z" transform="translate(-918 -492)"/> </g> </svg>
-                  <p>username@domain.com</p>
+                  <p>zeller@zeller1.com</p>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary
- replace homepage hero with Zeller Construction messaging and call-to-action
- list Zeller's service offerings and company overview on the homepage
- update contact information site-wide with Zeller's address, phones, and email

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689196b1ff40832ca62abd946ba1ab9a